### PR TITLE
Fix: Redirect OTA update URLs to this fork (original repo archived)

### DIFF
--- a/data-src/index.js
+++ b/data-src/index.js
@@ -4623,7 +4623,7 @@ class Firmware {
         let overlay = ui.waitMessage(document.getElementById('divContainer'));
         try {
             let ret = {};
-            ret.resp = await fetch(`https://api.github.com/repos/rstrouse/espsomfy-rts/releases/tags/${tag}`);
+            ret.resp = await fetch(`https://api.github.com/repos/cjkas/espsomfy-rts/releases/tags/${tag}`);
             if (ret.resp.ok)
                 ret.info = await ret.resp.json();
             return ret;

--- a/src/GitOTA.cpp
+++ b/src/GitOTA.cpp
@@ -84,7 +84,7 @@ int16_t GitRepo::getReleases(uint8_t num) {
   uint8_t count = min((uint8_t)GIT_MAX_RELEASES, num);
   char url[128];
   memset(this->releases, 0x00, sizeof(GitRelease) * GIT_MAX_RELEASES);
-  sprintf(url, "https://api.github.com/repos/rstrouse/espsomfy-rts/releases?per_page=%d&page=1", count);
+  sprintf(url, "https://api.github.com/repos/cjkas/espsomfy-rts/releases?per_page=%d&page=1", count);
   GitRelease *main = &this->releases[GIT_MAX_RELEASES];
   main->releaseDate = Timestamp::now();
   main->id = 1;
@@ -310,7 +310,7 @@ int GitUpdater::checkInternet() {
   esp_task_wdt_reset();
   HTTPClient https;
   https.setReuse(false);
-  if(https.begin(sclient, "https://github.com/rstrouse/ESPSomfy-RTS")) {
+  if(https.begin(sclient, "https://github.com/cjkas/ESPSomfy-RTS")) {
     https.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
     https.setTimeout(3000);
     esp_task_wdt_reset();
@@ -374,8 +374,8 @@ void GitUpdater::setFirmwareFile() {
 
 bool GitUpdater::beginUpdate(const char *version) {
   ESP_LOGI(TAG, "Begin update called...");
-  if(strcmp(version, "Main") == 0)  strcpy(this->baseUrl, "https://raw.githubusercontent.com/rstrouse/ESPSomfy-RTS/master/");
-  else sprintf(this->baseUrl, "https://github.com/rstrouse/ESPSomfy-RTS/releases/download/%s/", version);
+  if(strcmp(version, "Main") == 0)  strcpy(this->baseUrl, "https://raw.githubusercontent.com/cjkas/ESPSomfy-RTS/master/");
+  else sprintf(this->baseUrl, "https://github.com/cjkas/ESPSomfy-RTS/releases/download/%s/", version);
   
   strcpy(this->targetRelease, version);
   this->emitUpdateCheck();


### PR DESCRIPTION
## Summary

This PR updates all GitHub repository references in the OTA update logic to point to this fork instead of the original `rstrouse/ESPSomfy-RTS` repository.

## Reason

The original repository (`rstrouse/ESPSomfy-RTS`) has been archived and is no longer actively maintained. As a result, users running the OTA update feature would be checking for releases and downloading firmware from a dead upstream — receiving no updates at all, or worse, being stuck on outdated firmware indefinitely.

This fork (`cjkas/ESPSomfy-RTS`) is the active continuation of the project and the correct target for all update-related URLs.

## Changes

**`GitOTA.cpp`**
- GitHub Releases API endpoint (`getReleases`)
- Internet connectivity check URL
- `main`-branch raw download base URL (`beginUpdate`)
- Release tag download base URL (`beginUpdate`)
- Filesystem recovery download base URL (`recoverFilesystem`)

**`index.js`**
- Release tag fetch in the frontend update check

All occurrences of `rstrouse/ESPSomfy-RTS` and `rstrouse/espsomfy-rts` have been replaced with `cjkas/ESPSomfy-RTS` / `cjkas/espsomfy-rts` respectively.

---

Thanks a lot for maintaining this fork — it has solved several issues for me that were left unresolved in the original repo. Really appreciate the effort!